### PR TITLE
License check option and command line options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,24 @@
 
 ## SDF linter
 
-The sdflint.js program checks the validity of the given SDF file. By default the [sdf-validation.jso.json](sdflint/sdf-validation.jso.json) is used for schema check but different schema file can be given as a second parameter.
+The sdflint.js program checks the validity of the given SDF file.
 
-Usage: `node sdflint <sdf-file> [schemafile.json]`
+Usage: `node sdflint sdffile.sdf.json [options as key=value pairs]`
 
-Example: `node sdflint sdfobject-myfirstobject.sdf.json`
+Options:
+*  `schema` The filename of the JSON schema to use (default: [sdflint/sdf-validation.jso.json](sdflint/sdf-validation.jso.json))
+*  `license` The license string to accept as valid (default: don't check)
+    
+
+Example: `node sdflint sdfobject-myfirstobject.sdf.json license=BSD-3-Clause`
 
 The output is a JSON object with two fields:
 * errorCount: number of checks that failed (or 0 if all checks passed)
 * errors: object with field for each type of error encountered
   * fileName: errors on input filename
   * parse: errors parsing the input file as JSON
+  * validChars: errors with invalid characters in the model file
+  * license: errors detected in license check
   * schema: array of values with more details on schema errors
 
 For schema errors, the error messages are described in more detail here: https://github.com/epoberezkin/ajv#error-objects

--- a/sdflint/package.json
+++ b/sdflint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdflint",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "SDF linter",
   "main": "sdflint.js",
   "dependencies": {

--- a/sdflint/sdflint.js
+++ b/sdflint/sdflint.js
@@ -32,29 +32,44 @@ if (require.main === module) { /* run as stand-alone? */
     let sdfFile;
     let inFile = process.argv[2];
     let appDir = path.dirname(require.main.filename);
+    let options = {};
+    let schemaFile;
 
-    let schemaFile = process.argv.length > 3 ?
-     process.argv[3] : (appDir + "/" + DEF_SCHEMA_FILE);
+    process.argv.slice(3).forEach( (option) => {
+      let name = option.substring(0, option.indexOf("="));
+      let value = option.substring(option.indexOf("=") + 1);
+      options[name] = value;
+    });
+
+    schemaFile = options.schema ?
+      options.schema : (appDir + "/" + DEF_SCHEMA_FILE);
 
     fileNameCheck(inFile, res);
 
     try {
-      sdfFile = JSON.parse(fs.readFileSync(inFile,
-        { encoding: 'utf-8' }));
+      sdfFile = fs.readFileSync(inFile,
+        { encoding: 'utf-8' });
       schema = JSON.parse(fs.readFileSync(schemaFile,
         { encoding: 'utf-8' }));
-      sdfLint(sdfFile, schema, res);
-    } catch (err) {
-      res.errorCount = 1;
-      res.errors.parse = err.message;
-    }
+      } catch (err) {
+        res.errorCount++;
+        res.errors.parse = err.message;
+      }
 
+    sdfLint(sdfFile, schema, res, options);
     console.dir(res, {depth: null});
 
     process.exit(res.errorCount);
   }
   else {
-    console.log("Usage: node sdflint sdffile.json [schemafile.json]");
+    console.log(`
+    Usage: node sdflint sdffile.json [options as key=value pairs]
+
+    Options:
+     schema   The filename of the JSON schema to use
+     license  The license string to accept as valid
+    `
+  );
   }
 }
 
@@ -82,27 +97,54 @@ function validCharsCheck(sdfFile, res) {
 }
 
 
-function sdfLint(sdfFile, schema, res) {
-  let ajv = new Ajv(AJV_OPTIONS);
-
-  validCharsCheck(sdfFile, res);
-
-  if (! schema) {
-    schema = JSON.parse(fs.readFileSync(
-      DEF_SCHEMA_FILE, { encoding: 'utf-8' }));
+function licenseCheck(sdf, license, res) {
+  if (! sdf.info || ! sdf.info.license) {
+    res.errorCount++;
+    res.errors.license = "No license defined in model"
+  } else if (sdf.info.license != license) {
+    res.errorCount++;
+    res.errors.license = "Model has license '" + sdf.info.license +
+     "' expected '" + license + "'";
   }
+}
+
+
+function sdfLint(sdfFile, schema, res, options) {
+  let ajv = new Ajv(AJV_OPTIONS);
+  let sdf;
+
   if (! res) {
     res = {
       errorCount: 0,
       errors: {}
     };
   }
+  if (! options) {
+    options = {};
+  }
+
+  try {
+    sdf = JSON.parse(sdfFile);
+  } catch  (err) {
+    res.errorCount++;
+    res.errors.parse = err.message;
+  }
+  validCharsCheck(sdfFile, res);
+
+  if (! schema) {
+    schema = JSON.parse(fs.readFileSync(
+      DEF_SCHEMA_FILE, { encoding: 'utf-8' }));
+  }
 
   let validate = ajv.compile(schema);
 
-  if (!validate(sdfFile)) {
+  if (!validate(sdf)) {
     res.errors.schema = validate.errors;
     res.errorCount++;
+  }
+
+  if (options.license) {
+    licenseCheck(sdf, options.license, res);
   }
 
   return res;


### PR DESCRIPTION
Support for giving license to check from the info block as command line parameter. Also added better support for future command line parameters.

Note that schema file is now given with the `schema=` option so also change in the CI script is needed before merging this.