### PR TITLE
remove "format":"full" from AJV_OPTIONS

### DIFF
--- a/sdflint/sdflint.js
+++ b/sdflint/sdflint.js
@@ -8,8 +8,7 @@ const Ajv = require('ajv');
 const path = require('path');
 
 const AJV_OPTIONS = {
-  "allErrors": true,
-  "format": "full"
+  "allErrors": true
 }
 
 /* Regular expression for valid SDF file names */


### PR DESCRIPTION
Ran into an error caused by the "format":" full" option. 

Found this comment in the AJV repo ajv-formats uses "full" formats by default.
https://github.com/ajv-validator/ajv/issues/1416#issuecomment-769775088

Removing that line resolved my error. That being said, I'm not a node programmer and I am hacking my way through investigating SDF for my project, so this may not be a valid contribution.